### PR TITLE
Changed paths to reference demo data and models in repo

### DIFF
--- a/Demo/Kovach-Townsend_SPW.Rmd
+++ b/Demo/Kovach-Townsend_SPW.Rmd
@@ -14,7 +14,7 @@ This script will recurse through a folder and all subfolders to select all spect
 
 ```{r Define Folders}
 
-specfolder="/Users/kylekovach/Library/CloudStorage/GoogleDrive-me@kylekovach.com/My Drive/Conferences and Presentations/BioScape/Workshop/Spectra_Test"
+specfolder="Demo/Spectra_Test"
 
 ```
 
@@ -23,7 +23,7 @@ If applying partial least squares regression models (PLSR) to predict traits on 
 
 ```{r Define Models}
 
-specmodelpath="/Users/kylekovach/Library/CloudStorage/GoogleDrive-me@kylekovach.com/My Drive/Conferences and Presentations/BioScape/Workshop/Models/models_ASD_fresh_spectra"
+specmodelpath="Models/models_ASD_fresh_spectra"
 
 ```
 


### PR DESCRIPTION
This should make it easier for future workshops as no one would need to change the path - although they would need to setwd() to wherever they put the files if they're not working in an R project pulled from the repo